### PR TITLE
Use trim() for VERSION

### DIFF
--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -19,7 +19,7 @@ class Event extends PhpObj {
      * @return [String => Mixed]
      */
     public function read(array $opts) {
-        $version = str_replace(PHP_EOL, '', file_get_contents(__DIR__.'/../../VERSION'));
+        $version = trim(file_get_contents(__DIR__.'/../../VERSION'));
         return [
             'user' => $opts['userid'] < 1 ? null : $this->repo->readUser($opts['userid']),
             'relateduser' => $opts['relateduserid'] < 1 ? null : $this->repo->readUser($opts['relateduserid']),


### PR DESCRIPTION
Hi, here's a patch for this plugin which fixes the same issue as https://github.com/LearningLocker/xAPI-Recipe-Emitter/pull/18