### PR TITLE
Add support for H5P xAPI events

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -43,7 +43,8 @@ class Controller extends PhpObj {
         '\mod_facetoface\event\take_attendance' => 'FacetofaceAttended',
         '\core\event\course_completed'=>'CourseCompleted',
         '\mod_scorm\event\scoreraw_submitted'=>'ScormSubmitted',
-        '\mod_scorm\event\status_submitted'=>'ScormSubmitted'
+        '\mod_scorm\event\status_submitted'=>'ScormSubmitted',
+        '\mod_hvp\event\hvp_xapi' => 'H5PxAPIEvent'
     ];
     /**
      * Constructs a new Controller.

--- a/src/Events/H5PxAPIEvent.php
+++ b/src/Events/H5PxAPIEvent.php
@@ -1,0 +1,35 @@
+<?php namespace LogExpander\Events;
+use \LogExpander\Repository as Repository;
+use \stdClass as PhpObj;
+
+class H5PxAPIEvent extends PhpObj {
+    protected $repo;
+
+    /**
+     * Constructs a new Event.
+     * @param repository $repo
+     */
+    public function __construct(Repository $repo) {
+        $this->repo = $repo;
+    }
+
+    /**
+     * Reads data for an event.
+     * @param [String => Mixed] $opts
+     * @return [String => Mixed]
+     */
+    public function read(array $opts) {
+        $version = trim(file_get_contents(__DIR__.'/../../VERSION'));
+        return [
+            'user' => $opts['userid'] < 1 ? null : $this->repo->readUser($opts['userid']),
+            'relateduser' => $opts['relateduserid'] < 1 ? null : $this->repo->readUser($opts['relateduserid']),
+            'course' => $this->repo->readCourse($opts['courseid']),
+            'app' => $this->repo->readSite(),
+            'info' => (object) [
+                'https://moodle.org/' => $this->repo->readRelease(),
+                'https://github.com/LearningLocker/Moodle-Log-Expander' => $version,
+            ],
+            'event' => $opts,
+        ];
+    }
+}


### PR DESCRIPTION
This PR is part of a set (Moodle-Log-Expander + Moodle-xAPI-Translator + xAPI-Recipe-Emitter ), which is complementing the changes made in https://github.com/h5p/h5p-moodle-plugin/pull/114 as part of the Israeli Open University Academic English project (http://study.onl.co.il)

Please review and see if you can merge.